### PR TITLE
✨ Support RTL in Titles, Todo Lists, and Some Database Views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Generated Files by Google Chrome
+app.asar

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
-  "trailingComma": "none",
+  "trailingComma": "es5",
   "tabWidth": 2,
-  "semi": true,
+  "semi": false,
   "singleQuote": true,
   "bracketSpacing": false,
   "printWidth": 120

--- a/src/index.js
+++ b/src/index.js
@@ -1,46 +1,57 @@
 // We need to always know if the notion document is fully loaded in order
 // to observe any newly added blocks under notion-content-page element
-const MUTATIONS_QUEUE = [];
-const NOTION_DOCUMENT_MUTATION = new MutationObserver(onNotionDocumentLoaded);
-NOTION_DOCUMENT_MUTATION.observe(document, {childList: true, subtree: true});
+const MUTATIONS_QUEUE = []
+const NOTION_DOCUMENT_MUTATION = new MutationObserver(onNotionDocumentLoaded)
+NOTION_DOCUMENT_MUTATION.observe(document, {childList: true, subtree: true})
 
 // A mutation to observe newest added blocks to notion-content-page element
-const NOTION_PAGE_CONTENT_MUTATION = new MutationObserver(() => alignPageContentToRight());
+const NOTION_PAGE_CONTENT_MUTATION = new MutationObserver(() => alignPageContentToRight())
+
+// Used for detecting if the Notion page is loaded
+const ROOT_LEVEL_CLASS_NAMES = ['notion-page-content', 'notion-table-view', 'notion-board-view', 'notion-gallery-view']
 
 function alignListItemsToRight() {
-  const items = getListItems();
+  const items = getListItems()
 
   items.forEach((item) => {
-    item.style['text-align'] = 'start';
-  });
+    item.style['text-align'] = 'start'
+  })
 }
 
 function getListItems() {
-  return document.querySelectorAll("div[placeholder='List']");
+  return document.querySelectorAll("div[placeholder='List'], div[placeholder='To-do']")
 }
 
 function setBlocksDirectionToAuto() {
-  const blocks = getTopLevelBlocksWithoutDirAttribute();
+  const blocks = getTopLevelBlocksWithoutDirAttribute()
 
   blocks.forEach((block) => {
-    block.setAttribute('dir', 'auto');
-  });
+    block.setAttribute('dir', 'auto')
+  })
 }
 
 function getTopLevelBlocksWithoutDirAttribute() {
-  return document.querySelectorAll('.notion-page-content > div[data-block-id]:not([dir])');
+  return document.querySelectorAll(
+    `.notion-page-content > div[data-block-id]:not([dir]):not(.notion-column_list-block):not(.notion-collection_view_page-block),
+    [placeholder="Untitled"]:not([dir]),
+    .notion-column-block > div[data-block-id]:not([dir]),
+    notion-collection_view-block:not([dir]),
+    .notion-table-view:not([dir]),
+    .notion-board-view:not([dir]),
+    .notion-gallery-view:not([dir])`
+  )
 }
 
 function alignPageContentToRight() {
-  setBlocksDirectionToAuto();
-  alignListItemsToRight();
+  setBlocksDirectionToAuto()
+  alignListItemsToRight()
 }
 
 // === Main entry point
 
 function onNotionDocumentLoaded(mutationsList) {
-  if (isMutationQueueEmpty()) requestIdleCallback(idleAlginItemsToRight);
-  MUTATIONS_QUEUE.push(mutationsList);
+  if (isMutationQueueEmpty()) requestIdleCallback(idleAlginItemsToRight)
+  MUTATIONS_QUEUE.push(mutationsList)
 }
 
 // Idle observe changes on notion page then align items, reason we're doing that is we shouldn't
@@ -50,29 +61,29 @@ function idleAlginItemsToRight() {
   for (const mutation of MUTATIONS_QUEUE) {
     for (const {addedNodes} of mutation) {
       if (isNotionPageContentLoaded(addedNodes[0])) {
-        alignPageContentToRight();
-        
-        const $notionPageContent = document.getElementsByClassName('notion-page-content')[0] || undefined;
+        alignPageContentToRight()
+
+        const $notionPageContent = document.getElementsByClassName('notion-page-content')[0] || undefined
         if ($notionPageContent) {
-          NOTION_PAGE_CONTENT_MUTATION.disconnect();
-          NOTION_PAGE_CONTENT_MUTATION.observe($notionPageContent, {childList: true, subtree: false});
+          NOTION_PAGE_CONTENT_MUTATION.disconnect()
+          NOTION_PAGE_CONTENT_MUTATION.observe($notionPageContent, {childList: true, subtree: false})
         }
       }
     }
   }
 
   // Clean queue
-  MUTATIONS_QUEUE.splice(0, MUTATIONS_QUEUE.length);
+  MUTATIONS_QUEUE.splice(0, MUTATIONS_QUEUE.length)
 }
 
 function isMutationQueueEmpty() {
-  return !MUTATIONS_QUEUE.length;
+  return !MUTATIONS_QUEUE.length
 }
 
 function isNotionPageContentLoaded(node) {
   if (typeof node !== 'undefined') {
-    return node.className === 'notion-page-content';
+    return ROOT_LEVEL_CLASS_NAMES.includes(node.className)
   }
 
-  return false;
+  return false
 }


### PR DESCRIPTION
Support the following block types:
- Titles (Page titles and inline collection titles)
- Todo lists
- Databases
  - Table
  - Board
  - Gallery

This commit both restores changes that dragonwocky and Fahme added in 57e0985f76b4d93c7fb48a7aad08ab9469c5c0d8.

**Other Changes**
- Enforce ES5-supported trailing commas
- Remove semicolons and stop requiring them

Note: This adds in the changes from #16 and more.
